### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A comprehensive Model Context Protocol (MCP) server that combines the power of [ugrep](https://github.com/Genivia/ugrep) and [ast-grep](https://github.com/ast-grep/ast-grep) philosophies to deliver intelligent search and replace capabilities for modern development workflows.
 
+<a href="https://glama.ai/mcp/servers/@mixelpixx/CodeSeeker-MCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mixelpixx/CodeSeeker-MCP/badge" alt="CodeSeeker-MCP MCP server" />
+</a>
+
 ## 🚀 Features
 
 CodeSeeker provides AI assistants with complete search AND replace capabilities:


### PR DESCRIPTION
This PR adds a badge for the [CodeSeeker-MCP](https://glama.ai/mcp/servers/@mixelpixx/CodeSeeker-MCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mixelpixx/CodeSeeker-MCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mixelpixx/CodeSeeker-MCP/badge" alt="CodeSeeker-MCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.